### PR TITLE
Fix: updateTodoStatus is fired on render todo list

### DIFF
--- a/frontend/views/tasklist/task-list-view.ts
+++ b/frontend/views/tasklist/task-list-view.ts
@@ -30,7 +30,7 @@ export class TaskListView extends MobxLitElement {
             <div class="todo">
               <vaadin-checkbox
                 ?checked=${todo.done}
-                @checked-changed=${(e: CustomEvent) =>
+                @change=${(e: CustomEvent) =>
                   this.updateTodoStatus(todo, e)}
               ></vaadin-checkbox>
               ${todo.task}


### PR DESCRIPTION
Should fix:
https://github.com/marcushellberg/vaadin-fusion-mobx/issues/1

The fix has been done based on the documentation here:
https://cdn.vaadin.com/vaadin-checkbox/3.0.0/#/elements/vaadin-checkbox#events

> 
> change: CustomEvent
> Fired when the user commits a value change.
> 
> checked-changed: CustomEvent
> Fired when the checked property changes.