### PR TITLE
Update views when new todo added

### DIFF
--- a/frontend/stores/store.ts
+++ b/frontend/stores/store.ts
@@ -18,11 +18,19 @@ class Store {
 
   async saveTodo(todo: Todo) {
     const saved = await endpoint.saveTodo(todo);
-    if (todo.id === 0) {
+    if (this.isNewTodo(todo)) {
       this.addTodo(saved);
     } else {
       this.updateTodo(saved);
     }
+  }
+
+  private todoExists(todo: Todo) {
+    return this.todos.some((t) => t.id === todo.id);
+  }
+
+  private isNewTodo(todo: Todo) {
+    return !this.todoExists(todo);
   }
 
   private addTodo(todo: Todo) {


### PR DESCRIPTION
Detect new todo by seeing whether the `id` already exists rather than checking if the `id === 0`, which is not true.

Fixes: GH-3