### PR TITLE
Set `vaadin.pnpm.enable = true`

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@ spring.mustache.check-template-location = false
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters
 # vaadin.whitelisted-packages= org/vaadin/example
 
-vaadin.pnpm.enable=false
+vaadin.pnpm.enable=true


### PR DESCRIPTION
Without this, when I start the app, npm runs and `pnpm-lock.yaml` is
ignored and actually gets deleted and a `package-lock.json` is generated:

```
$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   .factorypath
        deleted:    pnpm-lock.yaml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        package-lock.json
```

I think this results in getting an incorrect set of package versions,
because I get a TypeScript compile error about `IReactionOptions` in
`frontend/view.ts`:

```
ERROR in /Users/abramowi/learn/mobx/vaadin-fusion-mobx/frontend/view.ts
./view.ts
[tsl] ERROR in /Users/abramowi/learn/mobx/vaadin-fusion-mobx/frontend/view.ts(22,12)
      TS2314: Generic type 'IReactionOptions' requires 2 type argument(s).
Child InjectManifest:
     1 asset
    Entrypoint InjectManifest = sw.js
       78 modules
ℹ ｢wdm｣: Failed to compile.
```

When I set `vaadin.pnpm.enable`, then it seems to use pnpm instead of
npm and then I don't end up getting the compile error.